### PR TITLE
Emit navigation events and display in example component

### DIFF
--- a/core/components/choice.tsx
+++ b/core/components/choice.tsx
@@ -85,7 +85,7 @@ const Choices = ({
 
         // TODO pull this out into a listener hook
         if (currentPlayer && sync) {
-            emitChoice(choiceId, identifier, tag, option, instanceId, currentPlayer)
+            emitChoice(choiceId, tag, option, identifier, instanceId, currentPlayer)
         }
 
         if (options.length === 1) {
@@ -95,6 +95,7 @@ const Choices = ({
                 // no-op
             } else if (typeof next === 'string') {
                 dispatch(gotoChapter(next))
+                emitNavChange(identifier, next, instanceId, currentPlayer)
             }
         }
         const s = {}

--- a/core/components/choice.tsx
+++ b/core/components/choice.tsx
@@ -95,7 +95,9 @@ const Choices = ({
                 // no-op
             } else if (typeof next === 'string') {
                 dispatch(gotoChapter(next))
-                emitNavChange(identifier, next, instanceId, currentPlayer)
+                if (currentPlayer && sync) {
+                    emitNavChange(identifier, next, instanceId, currentPlayer)
+                }
             }
         }
         const s = {}

--- a/core/multiplayer/api-client.ts
+++ b/core/multiplayer/api-client.ts
@@ -78,9 +78,9 @@ export const emitNavChange = (
 
 export const emitChoice = (
     id: string,
-    identifier: string,
     tag: Tag,
     option: string,
+    identifier: string,
     instanceId: string,
     player: Player
 ): void => {

--- a/core/multiplayer/components/multiplayer-init.tsx
+++ b/core/multiplayer/components/multiplayer-init.tsx
@@ -11,12 +11,12 @@ import { PresenceApiResponse } from 'pages/api/core/story/[story]/[instance]/pre
 export interface Players {
     currentPlayer: Player
     otherPlayer: Player
-    presence: PresenceApiResponse
+    presenceApiResponse: PresenceApiResponse
 }
 export const PlayerContext: React.Context<Players> = React.createContext({
     currentPlayer: null,
     otherPlayer: null,
-    presence: null
+    presenceApiResponse: null
 })
 
 const MultiplayerInit: React.FC = ({ children }) => {
@@ -28,7 +28,9 @@ const MultiplayerInit: React.FC = ({ children }) => {
     const log = useSelector((state: RootState) => state.log)
     const toc = useSelector((state: RootState) => state.toc.present)
 
-    const [presence, setPresence] = React.useState<PresenceApiResponse | undefined>(undefined)
+    const [presenceApiResponse, setPresence] = React.useState<PresenceApiResponse | undefined>(
+        undefined
+    )
 
     const dispatch = useDispatch()
 
@@ -71,7 +73,7 @@ const MultiplayerInit: React.FC = ({ children }) => {
     const PlayersContext: Players = {
         currentPlayer,
         otherPlayer,
-        presence
+        presenceApiResponse: presenceApiResponse
     }
 
     return (

--- a/core/multiplayer/components/presence.tsx
+++ b/core/multiplayer/components/presence.tsx
@@ -1,3 +1,9 @@
+/*
+    Example component for displaying the presence, or current status, of other
+    players. You will probably want to customize this for your story,
+    for example by mapping chapter names to something meaningful in your
+    story.
+*/
 import * as React from 'react'
 
 import styles from 'public/styles/multiplayer/Presence.module.scss'
@@ -5,7 +11,7 @@ import styles from 'public/styles/multiplayer/Presence.module.scss'
 import { PlayerContext } from './multiplayer-init'
 
 const Presence: React.FC = () => {
-    const { presence } = React.useContext(PlayerContext)
+    const { presenceApiResponse: presence } = React.useContext(PlayerContext)
     if (!presence) {
         return null
     }
@@ -15,7 +21,8 @@ const Presence: React.FC = () => {
             <ol className={styles.userList}>
                 <li>
                     <span className={presence.presence.createdAt ? styles.active : styles.inactive}>
-                        <span className={styles.cap}>{presence.player.name}</span> is{' '}
+                        <span className={styles.cap}>{presence.player.name}</span> is in{' '}
+                        {presence.nav.chapterName}
                         {/* {'true' === 'true' ? 'online' : 'offline'} */}
                     </span>
                 </li>

--- a/pages/api/core/story/[story]/[instance]/presence.ts
+++ b/pages/api/core/story/[story]/[instance]/presence.ts
@@ -1,4 +1,4 @@
-import { Presence, Player } from '@prisma/client'
+import { Presence, Player, Nav } from '@prisma/client'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import prisma from 'pages/api/db'
@@ -6,6 +6,7 @@ import prisma from 'pages/api/db'
 export type PresenceApiResponse = {
     presence: Presence
     player: Player
+    nav: Nav
 }
 
 export default async (
@@ -51,9 +52,19 @@ export default async (
                 player: true
             }
         })
+        const nav = await prisma.nav.findFirst({
+            where: {
+                player: presence.player
+            },
+            orderBy: {
+                createdAt: 'desc'
+            }
+        })
+        // TODO set this on all get requests?
         res.setHeader('Cache-Control', 's-maxage=10, stale-while-revalidate')
+
         if (presence !== null) {
-            res.status(200).json({ presence, player: presence.player })
+            res.status(200).json({ presence, player: presence.player, nav })
         } else {
             res.status(404).end()
         }


### PR DESCRIPTION
Emit an API call when a user does a chapter navigation event, return that info from the Presence API, and use that in the example presence component.