### PR TITLE
Fixes #193 with specific child selector

### DIFF
--- a/public/stories/manual/styles/Index.module.scss
+++ b/public/stories/manual/styles/Index.module.scss
@@ -56,7 +56,7 @@
     pre + p {
         padding-top: 1rem;
     }
-    code {
+    p > code, li > code {
         background: color.scale(colors.$cool, $lightness: 85%);
         padding: 4px;
     }


### PR DESCRIPTION
Use a direct child selector to target inline `<code>` elements rather than an element selector. `<code>` is used by `SyntaxHighlighter` internally, which was causing the first line of any code block to be erroneously indented.

Removing the padding altogether has an undesired side effect with the appearance of inline code; this should have just enough padding to make the background color stand out around the text.

Fix:

<img width="760" alt="image" src="https://user-images.githubusercontent.com/19571/144432537-c419b08d-07e3-4527-b20c-e8d95936f2ce.png">

(It's possible there are some other potential parents, but the visual difference is minor enough that it's not worth thoroughly checking.)