### PR TITLE
Add the hike story as an independent file

### DIFF
--- a/cypress/integration/core/demo.js
+++ b/cypress/integration/core/demo.js
@@ -54,6 +54,7 @@ describe('Full test of the built-in stories', () => {
         cy.get('a:contains("example story")').click()
 
         // Sample (ascent)
+        cy.get('a:contains("sample story")').click()
         cy.get('a:contains("your best friend")').click()
         cy.contains('Your companion will be your best friend.')
         cy.get('a:contains("Start your ascent")').click()
@@ -81,8 +82,8 @@ describe('Full test of the built-in stories', () => {
 
         // Sample (descent)
         cy.get('img').should('be.visible')
-        cy.get('a:contains("set out to meet them")').click()
-
+        cy.get('a:contains("Return to the manual")').click()
+        cy.get('a:contains("continue with the next section")').click()
         // Images
         cy.get('img[src="../stories/manual/images/example1.jpg"]').should('be.visible')
         cy.get('img[src="../stories/manual/images/skyscrapers.jpg"]').should('be.visible')

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="next" />
+/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/public/stories/manual/story.yaml
+++ b/public/stories/manual/story.yaml
@@ -15,10 +15,6 @@ chapters:
     title: "Navigation"
   - filename: "sample-ascent"
     title: "Sample story"
-  - filename: "sample-summit"
-    title: "Summit (Sample story)"
-  - filename: "sample-descent"
-    title: "Descent (Sample story)"
   - filename: "images"
     title: "Images"
   - filename: "styling"
@@ -30,7 +26,7 @@ chapters:
   - filename: "next"
     title: "Next steps and further resources"
 extra:
-  omitToc: ['sample-summit', 'sample-descent']
+  omitToc: []
 
 players:
   - start: "introduction"

--- a/public/stories/putney-mountain/story.yaml
+++ b/public/stories/putney-mountain/story.yaml
@@ -1,0 +1,11 @@
+title: On Putney Mountain
+language: en
+chapters:
+  - filename: "ascent"
+    title: "Ascent"
+  - filename: "summit"
+    title: "Summit"
+  - filename: "descent"
+    title: "Descent"
+players:
+  - start: "ascent"

--- a/public/stories/putney-mountain/styles/Index.module.scss
+++ b/public/stories/putney-mountain/styles/Index.module.scss
@@ -1,0 +1,43 @@
+@use '/public/styles/sizing' with (
+    $story-margin: 100px,
+    $font-size-default: 20px
+);
+@use '/public/styles/grid';
+@use '/public/styles/colors';
+
+.main {
+   .sample {
+
+      @media screen and (min-width: sizing.$big-viewport) {
+          margin: 0 10rem;
+      }
+      font-family: Nunito, serif;
+
+      p:first-of-type {
+          padding-top: 2rem;
+      }
+      h1, h2, h3, h4, h5, h6 {
+          color: colors.$very-dark;
+      }
+      // Ensure the underline doesn't go beneath the emoji for all findables
+      .findable a::after {
+          display: inline-block;
+          width: 0;
+          margin: 0 1em 0 .25em;
+      }
+      .camera a::after {
+          content: " 📸";
+
+      }
+      .food a::after {
+          content: " 🍄";
+      }
+      .magnify a::after {
+          content: " 🔎";
+      }
+
+      img {
+          padding-top: 2rem !important;
+      }
+  }
+}

--- a/stories/manual/chapters/sample-ascent.tsx
+++ b/stories/manual/chapters/sample-ascent.tsx
@@ -1,163 +1,20 @@
-import { capitalize } from 'lodash'
-import Image from 'next/image'
-
-import { C, R, Section, Chapter, Nav, When } from 'core/components'
-import { PageType, Next, Option } from 'core/types'
-import useInventory from 'core/hooks/use-inventory'
+import { Chapter, Nav } from 'core/components'
+import { PageType } from 'core/types'
 
 import { styles } from '..'
 
-export const allFindables: Option[] = ['chipmunk', 'mushroom', 'snake', 'hawk']
-
-export const Score = (): JSX.Element => {
-    const findables = useInventory(allFindables).filter((f) => !!f)
-    const [companion] = useInventory(['companion'])
-    return (
-        <When condition={findables.length}>
-            <section className={`windrift--section ${styles.sample}`}>
-                (You've found {findables.length} out of {allFindables.length} possible natural
-                items.
-                <When condition={findables.length >= 3}>
-                    {' '}
-                    It's time to meet up with {companion} and head home!
-                </When>
-                )
-            </section>
-        </When>
-    )
-}
-
 export const Page: PageType = () => {
-    const [companion, chipmunk, trunk, mushroom] = useInventory([
-        'companion',
-        'chipmunk',
-        'trunk',
-        'mushroom'
-    ])
-
     return (
         <Chapter filename="sample-ascent">
-            <Section>
-                <h1>Sample story: On Putney Mountain</h1>
-                <aside className={styles.note}>
-                    This is a sample story consisting of three chapters. If you'd like to continue
-                    with the manual, skip ahead to the section on{' '}
-                    <Nav text="images" next="images" />.
-                </aside>
-                <p>
-                    In this story, you are a young person hiking up a mountain on a beautiful autumn
-                    day in North America. Your goal is to observe three aspects of nature, at which
-                    point a companion will arrive to pick you up.
-                </p>
-                <When
-                    condition={companion}
-                    otherwise={
-                        <p>
-                            Will your companion be{' '}
-                            <C
-                                tag="companion"
-                                options={[['your dad', 'your sister', 'your best friend']]}
-                            />
-                            ?
-                        </p>
-                    }>
-                    <p>Your companion will be {companion}.</p>
-                </When>
-            </Section>
-            <Section className={styles.sample}>
-                <p style={{ marginTop: '4rem' }}>
-                    It's only early afternoon, but this late in the fall the sun is low in the sky.
-                    It casts long shadows, dappling through the trees, hiding nature's mysteries.
-                </p>
-                <p>
-                    {capitalize(companion)} said to call when you're done exploring, and to promise
-                    not to lose track of time. You, in turn, promised you'd limit yourself to
-                    observing just three natural wonders on this short hike up old Putney Mountain.
-                </p>
-                <Nav text="Start your ascent..." next={Next.Section} />
-            </Section>
-
-            <Section className={styles.sample}>
-                <Image
-                    src="../stories/manual/images/the-trout-pool-whittredge.jpg"
-                    unoptimized={true}
-                    alt="A painting of a forest in autumn with deep trees rendered in orange and gold"
-                    width="1000"
-                    height="406"
-                />
-                <h2>Putney Mountain Ascent</h2>
-                <p>
-                    The trailhead begins on the northeast slope and you find yourself in deep shade.
-                    Last night brought high winds, and the path is blanketed in an ankle-deep quilt
-                    of leaves, a rustling mosaic of gold and deep ruby.
-                </p>
-                <p>
-                    The path on one side is bordered by{' '}
-                    <C
-                        tag="border"
-                        options={[['a low rock wall', 'a felled sugar maple']]}
-                        last={'a low rock wall and a felled sugar maple'}
-                        extra={{ conjunction: 'and' }}
-                    />
-                    .
-                    <R
-                        tag="border"
-                        options={{
-                            wall: (
-                                <span>
-                                    {' '}
-                                    It's a vestige, really, a little strip of wall that in the 19th
-                                    century probably demarcated a farm or pasture. It's mortar-less,
-                                    hand-assembled from medium-size lumps of gneiss or shale,
-                                    pleasingly coated with lichen and moss. A{' '}
-                                    <C
-                                        tag="chipmunk"
-                                        options={[['bright-eyed chipmunk']]}
-                                        className={`${styles.findable} ${styles.camera}`}
-                                    />{' '}
-                                    peeks between a gap, watching you.
-                                    <When condition={chipmunk}>
-                                        {' '}
-                                        You take a photo of it, catching it between tail twitches.
-                                    </When>
-                                </span>
-                            ),
-                            maple: (
-                                <span>
-                                    {' '}
-                                    The tree has been dramatically split three ways down the center
-                                    line of the trunk, folded out like a peeled banana. The{' '}
-                                    <C tag="trunk" options={[['inside of the trunk']]} /> is
-                                    blackened throughout, with a deep hollow.
-                                    <When condition={trunk}>
-                                        {' '}
-                                        Growing along the inside of the hollow is a pristine
-                                        specimen of the edible{' '}
-                                        <C
-                                            tag="mushroom"
-                                            options={[['oyster mushroom']]}
-                                            className={`${styles.findable} ${styles.food}`}
-                                        />
-                                        , at peak freshness.
-                                    </When>
-                                    <When condition={mushroom}>
-                                        {' '}
-                                        You gently scoop it out and bag it.
-                                    </When>
-                                </span>
-                            )
-                        }}
-                    />
-                </p>
-                <p>
-                    The trail{' '}
-                    <When condition={mushroom || chipmunk} otherwise="climbs up">
-                        <Nav text="climbs up" next="sample-summit" />
-                    </When>{' '}
-                    into the cool light of the summit.
-                </p>
-            </Section>
-            <Score />
+            <h1>Sample story: On Putney Mountain</h1>
+            <aside className={styles.note}>
+                This is a sample story consisting of three chapters. If you'd like to continue with
+                the manual, skip ahead to the section on <Nav text="images" next="images" />.
+            </aside>
+            <p>
+                <a href="../putney-mountain">Begin the sample story</a> or{' '}
+                <Nav text="continue with the next section of the manual" next="images" />.
+            </p>
         </Chapter>
     )
 }

--- a/stories/putney-mountain/chapters/ascent.tsx
+++ b/stories/putney-mountain/chapters/ascent.tsx
@@ -1,0 +1,156 @@
+import { capitalize } from 'lodash'
+import Image from 'next/image'
+
+import { C, R, Section, Chapter, Nav, When } from 'core/components'
+import { PageType, Next, Option } from 'core/types'
+import useInventory from 'core/hooks/use-inventory'
+
+import styles from 'public/stories/putney-mountain/styles/Index.module.scss'
+
+export const Page: PageType = () => {
+    const [companion, chipmunk, trunk, mushroom] = useInventory([
+        'companion',
+        'chipmunk',
+        'trunk',
+        'mushroom'
+    ])
+
+    return (
+        <Chapter filename="ascent">
+            <Section className={styles.sample}>
+                <p>
+                    In this story, you are a young person hiking up a mountain on a beautiful autumn
+                    day in North America. Your goal is to observe three aspects of nature, at which
+                    point a companion will arrive to pick you up.
+                </p>
+                <When
+                    condition={companion}
+                    otherwise={
+                        <p>
+                            Will your companion be{' '}
+                            <C
+                                tag="companion"
+                                options={[['your dad', 'your sister', 'your best friend']]}
+                            />
+                            ?
+                        </p>
+                    }>
+                    <p>Your companion will be {companion}.</p>
+                </When>
+            </Section>
+            <Section className={styles.sample}>
+                <p style={{ marginTop: '4rem' }}>
+                    It's only early afternoon, but this late in the fall the sun is low in the sky.
+                    It casts long shadows, dappling through the trees, hiding nature's mysteries.
+                </p>
+                <p>
+                    {capitalize(companion)} said to call when you're done exploring, and to promise
+                    not to lose track of time. You, in turn, promised you'd limit yourself to
+                    observing just three natural wonders on this short hike up old Putney Mountain.
+                </p>
+                <Nav text="Start your ascent..." next={Next.Section} />
+            </Section>
+
+            <Section className={styles.sample}>
+                <Image
+                    src="../stories/manual/images/the-trout-pool-whittredge.jpg"
+                    unoptimized={true}
+                    alt="A painting of a forest in autumn with deep trees rendered in orange and gold"
+                    width="1000"
+                    height="406"
+                />
+                <h2>Putney Mountain Ascent</h2>
+                <p>
+                    The trailhead begins on the northeast slope and you find yourself in deep shade.
+                    Last night brought high winds, and the path is blanketed in an ankle-deep quilt
+                    of leaves, a rustling mosaic of gold and deep ruby.
+                </p>
+                <p>
+                    The path on one side is bordered by{' '}
+                    <C
+                        tag="border"
+                        options={[['a low rock wall', 'a felled sugar maple']]}
+                        last={'a low rock wall and a felled sugar maple'}
+                        extra={{ conjunction: 'and' }}
+                    />
+                    .
+                    <R
+                        tag="border"
+                        options={{
+                            wall: (
+                                <span>
+                                    {' '}
+                                    It's a vestige, really, a little strip of wall that in the 19th
+                                    century probably demarcated a farm or pasture. It's mortar-less,
+                                    hand-assembled from medium-size lumps of gneiss or shale,
+                                    pleasingly coated with lichen and moss. A{' '}
+                                    <C
+                                        tag="chipmunk"
+                                        options={[['bright-eyed chipmunk']]}
+                                        className={`${styles.findable} ${styles.camera}`}
+                                    />{' '}
+                                    peeks between a gap, watching you.
+                                    <When condition={chipmunk}>
+                                        {' '}
+                                        You take a photo of it, catching it between tail twitches.
+                                    </When>
+                                </span>
+                            ),
+                            maple: (
+                                <span>
+                                    {' '}
+                                    The tree has been dramatically split three ways down the center
+                                    line of the trunk, folded out like a peeled banana. The{' '}
+                                    <C tag="trunk" options={[['inside of the trunk']]} /> is
+                                    blackened throughout, with a deep hollow.
+                                    <When condition={trunk}>
+                                        {' '}
+                                        Growing along the inside of the hollow is a pristine
+                                        specimen of the edible{' '}
+                                        <C
+                                            tag="mushroom"
+                                            options={[['oyster mushroom']]}
+                                            className={`${styles.findable} ${styles.food}`}
+                                        />
+                                        , at peak freshness.
+                                    </When>
+                                    <When condition={mushroom}>
+                                        {' '}
+                                        You gently scoop it out and bag it.
+                                    </When>
+                                </span>
+                            )
+                        }}
+                    />
+                </p>
+                <p>
+                    The trail{' '}
+                    <When condition={mushroom || chipmunk} otherwise="climbs up">
+                        <Nav text="climbs up" next="summit" />
+                    </When>{' '}
+                    into the cool light of the summit.
+                </p>
+            </Section>
+            <Score />
+        </Chapter>
+    )
+}
+export const allFindables: Option[] = ['chipmunk', 'mushroom', 'snake', 'hawk']
+
+export const Score = (): JSX.Element => {
+    const findables = useInventory(allFindables).filter((f) => !!f)
+    const [companion] = useInventory(['companion'])
+    return (
+        <When condition={findables.length}>
+            <section className={`windrift--section ${styles.sample}`}>
+                (You've found {findables.length} out of {allFindables.length} possible natural
+                items.
+                <When condition={findables.length >= 3}>
+                    {' '}
+                    It's time to meet up with {companion} and head home!
+                </When>
+                )
+            </section>
+        </When>
+    )
+}

--- a/stories/putney-mountain/chapters/descent.tsx
+++ b/stories/putney-mountain/chapters/descent.tsx
@@ -4,12 +4,12 @@ import { Section, Chapter, Nav } from 'core/components'
 import { PageType } from 'core/types'
 import useInventory from 'core/hooks/use-inventory'
 
-import { styles } from '..'
+import styles from 'public/stories/putney-mountain/styles/Index.module.scss'
 
 export const Page: PageType = () => {
     const [companion] = useInventory(['companion'])
     return (
-        <Chapter filename="sample-descent">
+        <Chapter filename="descent">
             <Section className={styles.sample}>
                 <p>
                     The descent into the valley is steeper than the ascent (fortunately!) so you
@@ -29,8 +29,10 @@ export const Page: PageType = () => {
                 </p>
                 <p>
                     You can just make out the shape of {companion} waving at you in the distance.{' '}
-                    Satisfied by your short hike today,{' '}
-                    <Nav text="set out to meet them" next="images" />. (Exit the sample story here.)
+                    Satisfied by your short hike today, you join them.
+                </p>
+                <p>
+                    <a href="../manual">Return to the manual</a>.
                 </p>
                 <br />
                 <br />

--- a/stories/putney-mountain/chapters/summit.tsx
+++ b/stories/putney-mountain/chapters/summit.tsx
@@ -4,15 +4,15 @@ import { C, Section, Chapter, Nav, When } from 'core/components'
 import { PageType } from 'core/types'
 import useInventory from 'core/hooks/use-inventory'
 
-import { styles } from '..'
-import { allFindables, Score } from './sample-ascent'
+import styles from 'public/stories/putney-mountain/styles/Index.module.scss'
+import { allFindables, Score } from './ascent'
 
 export const Page: PageType = () => {
     const [rock, hawk, snake] = useInventory(['rock', 'hawk', 'snake'])
     const findables = useInventory(allFindables).filter((f) => !!f)
 
     return (
-        <Chapter filename="sample-summit">
+        <Chapter filename="summit">
             <Section className={styles.sample}>
                 <p>You emerge from tree cover beneath an overcast sky.</p>
                 <Image
@@ -67,7 +67,7 @@ export const Page: PageType = () => {
                 <p>
                     The trail{' '}
                     <When condition={findables.length >= 3} otherwise="continues north">
-                        <Nav text="continues north" next="sample-descent" />
+                        <Nav text="continues north" next="descent" />
                     </When>{' '}
                     down into the valley.
                 </p>

--- a/stories/putney-mountain/index.tsx
+++ b/stories/putney-mountain/index.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+
+import Grid from 'core/components/ui/layouts/grid'
+
+import styles from 'public/stories/putney-mountain/styles/Index.module.scss'
+
+const Index: React.FC = ({ children }) => {
+    return (
+        <Grid
+            styles={styles}
+            head={
+                <link
+                    href="https://fonts.googleapis.com/css2?family=Nunito:wght@300&family=EB+Garamond&family=Elsie&family=Roboto&&family=Roboto+Mono&display=block"
+                    rel="stylesheet"
+                />
+            }>
+            {children}
+        </Grid>
+    )
+}
+
+export default Index


### PR DESCRIPTION
This isn't as elegant as it could be because it's not possible to link directly to the subsequent section of the manual. I'd wanted to just import the child sections for both the independent and embedded version and that's doable, but not without some tricky code, which defeats the purpose of making this a very simple sample.