### PR TITLE
[#250] Add Sync entrypoint and some other cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 # Don't save cypress artifacts
 cypress/videos
 cypress/screenshots
+
+# Emacs junk
+*~

--- a/core/multiplayer/api-client.ts
+++ b/core/multiplayer/api-client.ts
@@ -1,4 +1,6 @@
-import useSWR from 'swr'
+import React from 'react'
+
+import useSWR, { useSWRConfig } from 'swr'
 import useSWRImmutable from 'swr/immutable'
 
 import { Nav, Player, Presence } from '@prisma/client'
@@ -247,8 +249,7 @@ export const useChoicePoll = (
         (player ? `?playerId=${player.id}` : '')
 
     const { data, error } = useSWR<ChoiceApiResponse[]>(url, fetcher, {
-        refreshInterval: 10000,
-        refreshWhenHidden: false
+        refreshInterval: 10000
     })
     if (data) {
         data.forEach((c) => {
@@ -260,4 +261,21 @@ export const useChoicePoll = (
         isError: error,
         isLoading: !error && !data
     }
+}
+
+/** Wrapper function to tell all relevant SWR calls to revalidate */
+export const useSync = (identifier: string, instanceId: string, player: Player): any => {
+    const [sync, doSync] = React.useState(false)
+    const { mutate } = useSWRConfig()
+    const choiceURL = `${API_PREFIX}/${identifier}/${instanceId}/listen/?playerId=${player.id}`
+    const navURL = `${API_PREFIX}/${identifier}/${instanceId}/nav/`
+
+    React.useEffect(() => {
+        if (sync) {
+            mutate(choiceURL)
+            mutate(navURL)
+            doSync(false)
+        }
+    })
+    return doSync
 }

--- a/core/multiplayer/components/debug.tsx
+++ b/core/multiplayer/components/debug.tsx
@@ -6,7 +6,7 @@ import { Player } from '@prisma/client'
 
 import { Config, RootState } from 'core/types'
 import { StoryContext } from 'pages/[story]/[[...chapter]]'
-import { emitNavChange, getStoryUrl, usePresencePoll } from 'core/multiplayer/api-client'
+import { emitNavChange, getStoryUrl, useSync, usePresencePoll } from 'core/multiplayer/api-client'
 
 import useLocation from '../hooks/use-location'
 
@@ -24,7 +24,8 @@ const Debug = (): JSX.Element => {
         <div className={debug.content}>
             <div>
                 <LocationSwitcher config={config} multiplayer={multiplayer} />
-                <UserSwitcher config={config} multiplayer={multiplayer} persistor={persistor} />
+                <UserSwitcher multiplayer={multiplayer} persistor={persistor} />
+                <SyncButton multiplayer={multiplayer} />
             </div>
             <div className={debug.log}>
                 <Log />
@@ -32,9 +33,19 @@ const Debug = (): JSX.Element => {
         </div>
     )
 }
+interface SyncProps {
+    multiplayer: Multiplayer
+}
+const SyncButton = ({ multiplayer }: SyncProps): JSX.Element => {
+    const doSync = useSync(multiplayer.identifier, multiplayer.instanceId, multiplayer.otherPlayer)
+    return (
+        <div>
+            <button onClick={() => doSync(true)}>Sync now</button>
+        </div>
+    )
+}
 
 interface UserSwitcherProps {
-    config: Config
     multiplayer: Multiplayer
     persistor: Persistor
 }

--- a/core/multiplayer/components/ready.tsx
+++ b/core/multiplayer/components/ready.tsx
@@ -19,9 +19,6 @@ const NEXT_PUBLIC_POLL_EMIT_PRESENCE = 30000
 const Ready: React.FC = ({ children }): JSX.Element => {
     const { multiplayer } = React.useContext(MultiplayerContext)
     const { identifier, players } = React.useContext(StoryContext).config
-    console.log(multiplayer)
-
-    console.log(players)
 
     const { toc } = useSelector((state: RootState) => state.navigation.present)
 

--- a/core/multiplayer/hooks/use-location.ts
+++ b/core/multiplayer/hooks/use-location.ts
@@ -20,10 +20,11 @@ const useLocation = (): Locations => {
         React.useContext(MultiplayerContext).multiplayer
 
     const { filename } = React.useContext(ChapterContext)
-
     const { navEntries } = useNavPoll(identifier, instanceId)
 
     // Before the API roundtrip has occurred, ensure we have local data for location checks like <Only>
+    // TODO possible to do this natively with SWR?
+
     let currentLocation: Nav = {
         playerId: currentPlayer.id,
         id: 'init',

--- a/stories/cloaks-of-darkness/chapters/cloakroom.tsx
+++ b/stories/cloaks-of-darkness/chapters/cloakroom.tsx
@@ -1,18 +1,11 @@
 import React from 'react'
-import { Duration } from 'luxon'
 
 import { C, R, Section, Chapter, Nav } from 'core/components'
-import { BaseList as D } from 'core/components/widgets'
 import { PageType } from 'core/types'
 
 import useCloak, { CloakStatus } from '../use-cloak'
-import { MultiplayerContext } from 'core/multiplayer/components/multiplayer'
 
-import Watch from 'core/multiplayer/components/watch'
-import Both from 'core/multiplayer/components/both'
 import Only from 'core/multiplayer/components/only'
-
-import Cycle from 'core/components/cycle'
 
 export const Page: PageType = () => {
     const cloak = useCloak()


### PR DESCRIPTION
Adds an entrypoint (callable example in the Debug toolbar) to immediately run the `Choice` and `Nav` syncs. Verified it does what's expected by disabling all the automatic polls–there is a lot of implicit polling due to how SWR works.