### PR TITLE
[#70] Add back in Pusher with simple client P2P notifications

### DIFF
--- a/core/multiplayer/components/multiplayer.tsx
+++ b/core/multiplayer/components/multiplayer.tsx
@@ -15,6 +15,9 @@ import { StoryContext } from 'pages/[story]/[[...chapter]]'
 import { useRouter } from 'next/router'
 import { Instance } from '../features/instance'
 
+export const POLL_FREQUENCY = process.env.NEXT_PUBLIC_PUSHER_KEY ? 100000 : 10000
+export const P2P_ENABLED = !!process.env.NEXT_PUBLIC_PUSHER_KEY
+
 export interface Multiplayer {
     identifier: string
     storyUrl: string

--- a/core/multiplayer/components/p2p/pusher.tsx
+++ b/core/multiplayer/components/p2p/pusher.tsx
@@ -1,0 +1,67 @@
+/** Implement Pusher auth/channel subscription for P2P events */
+
+import * as React from 'react'
+import debounce from 'lodash.debounce'
+
+import {
+    PusherProvider,
+    useClientTrigger,
+    useEvent,
+    usePresenceChannel
+} from '@harelpls/use-pusher'
+import { MultiplayerContext } from '../multiplayer'
+import { useSelector } from 'react-redux'
+import { RootState } from 'core/types'
+import { syncBuiltinESMExports } from 'module'
+import { useSync } from 'core/multiplayer/api-client'
+
+const Pusher: React.FC = ({ children }): JSX.Element => {
+    const { otherPlayer } = React.useContext(MultiplayerContext).multiplayer
+
+    const config = {
+        clientKey: process.env.NEXT_PUBLIC_PUSHER_KEY,
+        cluster: process.env.NEXT_PUBLIC_PUSHER_CLUSTER,
+        authEndpoint: '/api/core/auth/',
+        auth: {
+            params: { playerId: otherPlayer.id }
+        }
+    }
+    return (
+        <PusherProvider {...config}>
+            <Listener>{children}</Listener>
+        </PusherProvider>
+    )
+}
+
+/** Subscribe to story channel */
+
+const Listener: React.FC = ({ children }): JSX.Element => {
+    const { instanceId, identifier, otherPlayer } = React.useContext(MultiplayerContext).multiplayer
+    const channelName = `presence-${instanceId}`
+    const { channel } = usePresenceChannel(channelName)
+    const trigger = useClientTrigger(channel)
+    const doSync = useSync(identifier, instanceId, otherPlayer)
+
+    // On any choice made by this player, indicate that they had a state change
+    // TODO this will also fire on propagated changes; do we care?
+    const choice = useSelector((state: RootState) => {
+        return state.choices.present
+    })
+    const triggerFunc = () => {
+        console.log('Sending client-moved')
+        trigger('client-moved', {})
+    }
+    const debouncedTrigger = React.useMemo(() => debounce(triggerFunc, 300), [choice])
+
+    useEvent(channel, 'client-moved', ({ data }) => {
+        console.log('Got client-moved event')
+        doSync(true)
+    })
+
+    React.useEffect(() => {
+        debouncedTrigger()
+    }, [choice])
+
+    return <>{children}</>
+}
+export default Pusher

--- a/core/multiplayer/components/ready.tsx
+++ b/core/multiplayer/components/ready.tsx
@@ -10,11 +10,10 @@ import { RootState } from 'core/types'
 import { gotoChapter } from 'core/features/navigation'
 import { emitNavChange, emitPresence, useChoicePoll } from '../api-client'
 import { useInterval } from 'usehooks-ts'
-import { MultiplayerContext } from './multiplayer'
+import { MultiplayerContext, POLL_FREQUENCY } from './multiplayer'
 import { init } from '../features/instance'
 import { makeChoice } from 'core/features/choice'
-
-const NEXT_PUBLIC_POLL_EMIT_PRESENCE = 30000
+import Pusher from './p2p/pusher'
 
 const Ready: React.FC = ({ children }): JSX.Element => {
     const { multiplayer } = React.useContext(MultiplayerContext)
@@ -58,7 +57,11 @@ const Ready: React.FC = ({ children }): JSX.Element => {
     return (
         <>
             {multiplayer.ready && <Polls />}
-            {children}
+            {process.env.NEXT_PUBLIC_PUSHER_KEY && multiplayer.ready ? (
+                <Pusher>{children}</Pusher>
+            ) : (
+                children
+            )}
         </>
     )
 }
@@ -96,10 +99,10 @@ const Polls = (): JSX.Element => {
             })
     }, [choices])
 
-    // Send presence
+    // Send presence manually if Pusher is not present
     useInterval(async () => {
         emitPresence(multiplayer.identifier, multiplayer.instanceId, multiplayer.currentPlayer.id)
-    }, NEXT_PUBLIC_POLL_EMIT_PRESENCE)
+    }, POLL_FREQUENCY)
 
     return null
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,6 +193,16 @@
                 }
             }
         },
+        "@harelpls/use-pusher": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@harelpls/use-pusher/-/use-pusher-7.2.1.tgz",
+            "integrity": "sha512-e94JTkNsaVKDnB6j6j4P3RRAGSNtMN6V+f3Or+gwe3TsdLUlpeGrw7JchIsSLmsxYvnJwS4YRees4fbuHLeQFQ==",
+            "requires": {
+                "dequal": "^2.0.1",
+                "invariant": "^2.2.4",
+                "pusher-js": "^7.0.0"
+            }
+        },
         "@humanwhocodes/config-array": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -804,6 +814,14 @@
             "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-1.2.6.tgz",
             "integrity": "sha512-ZLDMxMvOL0xd7FBHXQJ9EJxPohw+qzpgwulaNhXGgPuFUfnS9mboUEyj0sU9A9F7lMJFPJ6gs8UfVxBY2eNnGA==",
             "dev": true
+        },
+        "abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "requires": {
+                "event-target-shim": "^5.0.0"
+            }
         },
         "acorn": {
             "version": "7.4.1",
@@ -1578,6 +1596,11 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
+        "dequal": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+            "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+        },
         "diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -2065,6 +2088,11 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
+        },
+        "event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
         },
         "eventemitter2": {
             "version": "6.4.5",
@@ -2633,6 +2661,14 @@
                 "side-channel": "^1.0.4"
             }
         },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
         "is-alphabetical": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
@@ -2646,6 +2682,11 @@
                 "is-alphabetical": "^1.0.0",
                 "is-decimal": "^1.0.0"
             }
+        },
+        "is-base64": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-1.1.0.tgz",
+            "integrity": "sha512-Nlhg7Z2dVC4/PTvIFkgVVNvPHSO2eR/Yd0XzhGiXCXEvWnptXlXa/clQ8aePPiMuxEGcWfzWbGw2Fe3d+Y3v1g=="
         },
         "is-bigint": {
             "version": "1.0.4",
@@ -3067,6 +3108,11 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+        },
+        "lodash.debounce": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
         },
         "lodash.merge": {
             "version": "4.6.2",
@@ -3669,6 +3715,40 @@
             "dev": true,
             "requires": {
                 "escape-goat": "^2.0.0"
+            }
+        },
+        "pusher": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/pusher/-/pusher-5.0.1.tgz",
+            "integrity": "sha512-1JK/xdjEdZQ7iJwbDWA0qBdPHGNvVSoUiNXA9O7j1BHYAqenSxyORgzxWQopnYFKjQhHIcCZ8RCKJtcepWHeKw==",
+            "requires": {
+                "abort-controller": "^3.0.0",
+                "is-base64": "^1.1.0",
+                "node-fetch": "^2.6.1",
+                "tweetnacl": "^1.0.0",
+                "tweetnacl-util": "^0.15.0"
+            },
+            "dependencies": {
+                "tweetnacl": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+                    "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+                }
+            }
+        },
+        "pusher-js": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-7.0.6.tgz",
+            "integrity": "sha512-I44FTlF2OfGNg/4xcxmFq/JqFzJswoQWtWCPq+DkCh31MFg3Qkm3bNFvTXU+c5KR19TyBZ9SYlYq2rrpJZzbIA==",
+            "requires": {
+                "tweetnacl": "^1.0.3"
+            },
+            "dependencies": {
+                "tweetnacl": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+                    "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+                }
             }
         },
         "qs": {
@@ -4458,6 +4538,11 @@
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
+        },
+        "tweetnacl-util": {
+            "version": "0.15.1",
+            "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+            "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
         },
         "type": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "node": "=14"
     },
     "dependencies": {
+        "@harelpls/use-pusher": "^7.2.1",
         "@prisma/client": "^3.7.0",
         "@reduxjs/toolkit": "^1.6.2",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -30,9 +31,11 @@
         "axios": "^0.24.0",
         "json-schema": "^0.4.0",
         "lodash.clonedeep": "^4.5.0",
+        "lodash.debounce": "^4.0.8",
         "luxon": "^2.2.0",
         "next": "^12.0.7",
         "prisma": "^3.7.0",
+        "pusher": "^5.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-error-boundary": "^3.1.0",

--- a/pages/api/core/auth.ts
+++ b/pages/api/core/auth.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import * as Pusher from 'pusher'
+
+// Authorize a user to Pusher
+
+// Username is just channel + '-' + player id
+
+export default (req: NextApiRequest, res: NextApiResponse): void => {
+    if (req.method === 'POST') {
+        const { PUSHER_APP_ID, NEXT_PUBLIC_PUSHER_KEY, PUSHER_SECRET, NEXT_PUBLIC_PUSHER_CLUSTER } =
+            process.env
+        const pusher = Pusher.forCluster(NEXT_PUBLIC_PUSHER_CLUSTER, {
+            appId: PUSHER_APP_ID,
+            key: NEXT_PUBLIC_PUSHER_KEY,
+            secret: PUSHER_SECRET,
+            useTLS: true
+        })
+        const { channel_name, socket_id, player } = req.body
+        const channelData = {
+            user_id: `${channel_name}--${player}`
+        }
+        const auth = pusher.authenticate(socket_id, channel_name, channelData)
+        res.send(auth)
+    }
+}

--- a/stories/cloaks-of-darkness/chapters/foyer.tsx
+++ b/stories/cloaks-of-darkness/chapters/foyer.tsx
@@ -10,7 +10,7 @@ export const Page: PageType = () => {
     return (
         <Chapter filename="foyer">
             <Section>
-                <h1>Foyer of the Opera House</h1>
+                <h1>Foyer of the Opera House </h1>
                 <p>
                     You are in a spacious hall, splendidly decorated in red and gold, with
                     glittering chandeliers overhead.{' '}


### PR DESCRIPTION
Add back in [Pusher](https://pusher.com) support for P2P-like client messaging. 

This only enables presence channel notifications for the purposes of pinging the sync endpoint added in #250. In local tests it seems to work well.

It's designed to have a fallback to simple polling if a Pusher config is not defined. In the future it would be better to package this independently so the messaging layer can be abstracted out and not require the Pusher dependencies in the core package.