### PR TITLE
[#233] Replay all changes from the same player if not present

### DIFF
--- a/core/components/choice.tsx
+++ b/core/components/choice.tsx
@@ -31,8 +31,6 @@ export interface ChoiceProps {
     className?: string
     /** For Multiplayer only, has no effect in single-player: whether to sync this choice to the remote player */
     sync?: boolean
-    /** For Multiplayer only, has no effect in single-player: whether a synced choice triggers the next parameter */
-    syncNext?: boolean
 }
 
 const Choice = ({
@@ -45,8 +43,7 @@ const Choice = ({
     last = null,
     defaultOption = null,
     className = null,
-    sync = true,
-    syncNext = false
+    sync = true
 }: ChoiceProps): JSX.Element => {
     const dispatch = useDispatch()
     const choice = useSelector((state: RootState) => {
@@ -69,7 +66,6 @@ const Choice = ({
                 last={last}
                 className={className}
                 sync={sync}
-                syncNext={syncNext}
             />
         )
     }
@@ -85,8 +81,7 @@ const MutableChoice = ({
     persist,
     last,
     className,
-    sync,
-    syncNext
+    sync
 }: ChoiceProps): JSX.Element => {
     const dispatch = useDispatch()
     const { filename } = React.useContext(ChapterContext)
@@ -104,7 +99,7 @@ const MutableChoice = ({
               identifier: config.identifier,
               instanceId: multiplayer.instanceId,
               sync,
-              syncNext
+              emit: true
           }
         : null
 

--- a/core/features/choice.ts
+++ b/core/features/choice.ts
@@ -41,7 +41,7 @@ export interface MultiplayerChoicePayload {
     identifier: string
     instanceId: string
     sync: boolean
-    syncNext: boolean
+    emit: boolean
     choiceId?: string
 }
 export const makeChoice =
@@ -74,15 +74,21 @@ export const makeChoice =
 
         const { resolved } = choices.present[tag]
 
+        console.log('Resolved: ', resolved)
         // If we've now exhausted the list of possible choices, invoke `next`
-        if (resolved) {
+        // In Multiplayer, only invoke next for choices made by the current player
+        if (
+            resolved &&
+            (!multiplayer || multiplayer.eventPlayer.id === multiplayer.currentPlayer.id)
+        ) {
+            console.log('In resolved: ', multiplayer.eventPlayer, multiplayer.currentPlayer)
             if (next === Next.Section) {
                 dispatch(incrementSection({ filename }))
             } else if (next === Next.None) {
                 // no-op
             } else if (typeof next === 'string') {
                 dispatch(gotoChapter({ filename: next }))
-                if (multiplayer) {
+                if (multiplayer && multiplayer.emit) {
                     emitNavChange(
                         multiplayer.identifier,
                         next, // Where they're going
@@ -92,12 +98,12 @@ export const makeChoice =
                     )
                 }
             }
-            if (multiplayer && multiplayer.eventPlayer === multiplayer.currentPlayer) {
+            if (multiplayer && multiplayer.emit) {
                 emitChoice(
                     choiceId,
                     tag,
                     option,
-                    multiplayer.syncNext ? next : null,
+                    next,
                     filename,
                     multiplayer.identifier,
                     multiplayer.instanceId,

--- a/core/features/choice.ts
+++ b/core/features/choice.ts
@@ -81,7 +81,6 @@ export const makeChoice =
             resolved &&
             (!multiplayer || multiplayer.eventPlayer.id === multiplayer.currentPlayer.id)
         ) {
-            console.log('In resolved: ', multiplayer.eventPlayer, multiplayer.currentPlayer)
             if (next === Next.Section) {
                 dispatch(incrementSection({ filename }))
             } else if (next === Next.None) {

--- a/core/multiplayer/api-client.ts
+++ b/core/multiplayer/api-client.ts
@@ -151,7 +151,9 @@ export const emitNavChange = (
         })
         .then(() => {
             emitPresence(identifier, instanceId, playerId)
-            console.log(`Posted nav change event for player ${playerId}`)
+            console.log(
+                `Posted nav change event for player ${playerId} moving from ${from} to ${chapterName}`
+            )
         })
         .catch((error) => console.error(error))
 }

--- a/core/multiplayer/components/ready.tsx
+++ b/core/multiplayer/components/ready.tsx
@@ -68,11 +68,7 @@ const Polls = (): JSX.Element => {
 
     const dispatch = useDispatch()
 
-    const { choices } = useChoicePoll(
-        multiplayer.identifier,
-        multiplayer.instanceId,
-        multiplayer.otherPlayer
-    )
+    const { choices } = useChoicePoll(multiplayer.identifier, multiplayer.instanceId)
 
     // Poll for choices
     React.useEffect(() => {
@@ -81,6 +77,7 @@ const Polls = (): JSX.Element => {
             .filter((row) => !logIds.includes(row.id))
             .forEach((row) => {
                 const { id, tag, option, next, chapterName, player } = row
+                console.log(`Replaying event ${tag} / ${next}`)
                 dispatch(
                     makeChoice(tag, option, next, chapterName, {
                         eventPlayer: player,
@@ -88,8 +85,8 @@ const Polls = (): JSX.Element => {
                         identifier: multiplayer.identifier,
                         instanceId: multiplayer.instanceId,
                         sync: false,
-                        syncNext: false,
-                        choiceId: id
+                        choiceId: id,
+                        emit: false
                     })
                 )
             })

--- a/pages/api/core/story/[story]/[instance]/listen.ts
+++ b/pages/api/core/story/[story]/[instance]/listen.ts
@@ -5,7 +5,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import prisma from 'core/multiplayer/db'
 
 export type ChoiceApiResponse = Choice & {
-    player: Player
+    player?: Player
 }
 
 export default async (
@@ -18,11 +18,13 @@ export default async (
         const choices = await prisma.choice.findMany({
             where: {
                 instanceId,
-                synced: true,
                 playerId
             },
             include: {
                 player: true
+            },
+            orderBy: {
+                createdAt: 'asc' // Replay in order
             }
         })
         res.status(200).json(choices)


### PR DESCRIPTION
* Drop the confusing `syncNext` param
* Add an `emit` param to independently assess whether to emit an event, and don't emit changes that are just replays from the same player
* Fix incorrect identity comparison (compare Player ids as strings, not Player objects)
* Pull all events from the `listen` API, not just synced events from the other player 