### PR TITLE
[#264] Resolve checking for status on local choice

### DIFF
--- a/core/components/choice.tsx
+++ b/core/components/choice.tsx
@@ -12,6 +12,8 @@ import { init as initInventory } from 'core/features/inventory'
 import useInventory from 'core/hooks/use-inventory'
 import { StoryContext } from 'pages/[story]/[[...chapter]]'
 import { MultiplayerContext } from 'core/multiplayer/components/multiplayer'
+import { useSWRConfig } from 'swr'
+import { getChoiceListenerURL, getNavListenerURL } from 'core/multiplayer/api-client'
 
 export interface ChoiceProps {
     tag: string
@@ -91,6 +93,7 @@ const MutableChoice = ({
     })
     const { multiplayer } = React.useContext(MultiplayerContext)
     const [inventory] = useInventory([tag])
+    const { mutate } = useSWRConfig()
 
     const multiplayerPayload: MultiplayerChoicePayload = multiplayer?.currentPlayer
         ? {
@@ -119,6 +122,10 @@ const MutableChoice = ({
             group = [last]
         } else {
             group = [inventory]
+        }
+        if (multiplayer) {
+            mutate(getChoiceListenerURL(multiplayer.identifier, multiplayer.instanceId))
+            mutate(getNavListenerURL(multiplayer.identifier, multiplayer.instanceId))
         }
     }
 

--- a/core/features/choice.ts
+++ b/core/features/choice.ts
@@ -7,7 +7,8 @@ import { Tag, ENTRY_TYPES, Next, Config, NextType, RootState } from 'core/types'
 import { gotoChapter, incrementSection } from 'core/features/navigation'
 import { increment } from 'core/features/counter'
 import { Player } from '@prisma/client'
-import { emitChoice, emitNavChange } from 'core/multiplayer/api-client'
+import { emitChoice, emitNavChange, useSync } from 'core/multiplayer/api-client'
+import { useSWRConfig } from 'swr'
 
 export type Option = string
 export type OptionGroup = Array<Option>
@@ -54,7 +55,6 @@ export const makeChoice =
     ) =>
     (dispatch: Dispatch, getState: () => RootState, config: Config): void => {
         const choiceId = multiplayer?.choiceId || uuidv4()
-
         dispatch(updateInventory({ tag, option }))
         dispatch(advance({ tag }))
         dispatch(
@@ -74,7 +74,6 @@ export const makeChoice =
 
         const { resolved } = choices.present[tag]
 
-        console.log('Resolved: ', resolved)
         // If we've now exhausted the list of possible choices, invoke `next`
         // In Multiplayer, only invoke next for choices made by the current player
         if (

--- a/core/multiplayer/api-client.ts
+++ b/core/multiplayer/api-client.ts
@@ -30,6 +30,15 @@ export const getStoryUrl = (instanceId: string): string => {
     const { protocol, hostname, port, pathname } = window.location
     return `${protocol}//${hostname}${port ? ':' + port : ''}${pathname}?instance=${instanceId}`
 }
+
+export const getChoiceListenerURL = (identifier: string, instanceId: string): string => {
+    return `${API_PREFIX}/${identifier}/${instanceId}/listen/`
+}
+
+export const getNavListenerURL = (identifier: string, instanceId: string): string => {
+    return `${API_PREFIX}/${identifier}/${instanceId}/nav/`
+}
+
 const fetcher = (url: string) => axios.get(url).then((res) => res.data)
 
 interface MultiplayerResponse {
@@ -266,8 +275,7 @@ export const useChoicePoll = (
     player?: Player
 ): ChoicePollResponse => {
     const url =
-        `${API_PREFIX}/${identifier}/${instanceId}/listen/` +
-        (player ? `?playerId=${player.id}` : '')
+        getChoiceListenerURL(identifier, instanceId) + (player ? `?playerId=${player.id}` : '')
 
     const { data, error } = useSWR<ChoiceApiResponse[]>(url, fetcher, SWR_CONFIG)
     if (data) {
@@ -283,16 +291,14 @@ export const useChoicePoll = (
 }
 
 /** Wrapper function to tell all relevant SWR calls to revalidate */
-export const useSync = (identifier: string, instanceId: string, player: Player): any => {
+export const useSync = (identifier: string, instanceId: string): any => {
     const [sync, doSync] = React.useState(false)
     const { mutate } = useSWRConfig()
-    const choiceURL = `${API_PREFIX}/${identifier}/${instanceId}/listen/?playerId=${player.id}`
-    const navURL = `${API_PREFIX}/${identifier}/${instanceId}/nav/`
 
     React.useEffect(() => {
         if (sync) {
-            mutate(choiceURL)
-            mutate(navURL)
+            mutate(getChoiceListenerURL(identifier, instanceId))
+            mutate(getNavListenerURL(identifier, instanceId))
             doSync(false)
         }
     })

--- a/core/multiplayer/components/debug.tsx
+++ b/core/multiplayer/components/debug.tsx
@@ -37,7 +37,7 @@ interface SyncProps {
     multiplayer: Multiplayer
 }
 const SyncButton = ({ multiplayer }: SyncProps): JSX.Element => {
-    const doSync = useSync(multiplayer.identifier, multiplayer.instanceId, multiplayer.otherPlayer)
+    const doSync = useSync(multiplayer.identifier, multiplayer.instanceId)
     return (
         <div>
             <button onClick={() => doSync(true)}>Sync now</button>

--- a/core/multiplayer/components/p2p/pusher.tsx
+++ b/core/multiplayer/components/p2p/pusher.tsx
@@ -41,11 +41,11 @@ const Pusher: React.FC = ({ children }): JSX.Element => {
 /** Subscribe to story channel */
 
 const Listener: React.FC = ({ children }): JSX.Element => {
-    const { instanceId, identifier, otherPlayer } = React.useContext(MultiplayerContext).multiplayer
+    const { instanceId, identifier } = React.useContext(MultiplayerContext).multiplayer
     const channelName = `presence-${instanceId}`
     const { channel } = usePresenceChannel(channelName)
     const trigger = useClientTrigger(channel)
-    const doSync = useSync(identifier, instanceId, otherPlayer)
+    const doSync = useSync(identifier, instanceId)
 
     // On any choice made by this player, indicate that they had a state change
     // TODO this will also fire on propagated changes; do we care?

--- a/core/multiplayer/components/watch.tsx
+++ b/core/multiplayer/components/watch.tsx
@@ -34,7 +34,7 @@ interface Props {
 export const Watch = ({ enter, exit, here, elsewhere }: Props): JSX.Element => {
     const { current, other } = useLocation()
 
-    usePresence()
+    const { isActive, lastSeen } = usePresence()
 
     const thisPlayerLocation = useChapter()?.filename
 


### PR DESCRIPTION
Call `mutate` on the relevant choice and nav endpoints to flush the cache and trigger a revalidation after a local choice has been made. This ensures that local state like location checks are current.