### PR TITLE
Don't use redux-persist in multiplayer games

### DIFF
--- a/core/components/ui/reset-button.tsx
+++ b/core/components/ui/reset-button.tsx
@@ -17,18 +17,26 @@ export const resetStory = (
     const url = '/' + router.basePath + config.identifier
     if (userInitiated) {
         if (confirm(message)) {
+            if (persistor) {
+                persistor.flush().then(() => {
+                    persistor.pause()
+                    localStorage.clear()
+                    window.location.replace(url)
+                })
+            } else {
+                window.location.replace(url)
+            }
+        }
+    } else {
+        if (persistor) {
             persistor.flush().then(() => {
                 persistor.pause()
                 localStorage.clear()
-                window.location.replace(url)
+                window.location.reload()
             })
-        }
-    } else {
-        persistor.flush().then(() => {
-            persistor.pause()
-            localStorage.clear()
+        } else {
             window.location.reload()
-        })
+        }
     }
 }
 type ResetType = {

--- a/core/features/navigation.ts
+++ b/core/features/navigation.ts
@@ -36,8 +36,8 @@ export const navSlice = createSlice({
         incrementSection: (state, action: PayloadAction<IncrementSectionPayload>) => {
             const { filename } = action.payload
             const item = getChapter(state.toc, filename)
-
-            item.bookmark = Math.min(item.bookmark + 1, item.sectionCount)
+            const sectionCount = item.sectionCount || 0 // Guard against sectionCount not being computed yet
+            item.bookmark = Math.min(item.bookmark + 1, sectionCount)
         },
         setSectionCount: (state, action: PayloadAction<CountSectionPayload>) => {
             const { filename, count } = action.payload

--- a/core/multiplayer/components/debug.tsx
+++ b/core/multiplayer/components/debug.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { Persistor } from 'redux-persist'
 import { useSelector } from 'react-redux'
 
 import { Player } from '@prisma/client'
@@ -19,12 +18,12 @@ import Log from './examples/log'
  */
 const Debug = (): JSX.Element => {
     const { multiplayer } = React.useContext(MultiplayerContext)
-    const { config, persistor } = React.useContext(StoryContext)
+    const { config } = React.useContext(StoryContext)
     return (
         <div className={debug.content}>
             <div>
                 <LocationSwitcher config={config} multiplayer={multiplayer} />
-                <UserSwitcher multiplayer={multiplayer} persistor={persistor} />
+                <UserSwitcher multiplayer={multiplayer} />
                 <SyncButton multiplayer={multiplayer} />
             </div>
             <div className={debug.log}>
@@ -47,27 +46,19 @@ const SyncButton = ({ multiplayer }: SyncProps): JSX.Element => {
 
 interface UserSwitcherProps {
     multiplayer: Multiplayer
-    persistor: Persistor
 }
 
-const UserSwitcher = ({ multiplayer, persistor }: UserSwitcherProps): JSX.Element => {
+const UserSwitcher = ({ multiplayer }: UserSwitcherProps): JSX.Element => {
     return (
         <div>
             Switch user to{' '}
             <button
                 onClick={() => {
-                    persistor.flush().then(() => {
-                        persistor.pause()
-                        persistor.purge().then(() => {
-                            localStorage.clear()
-                            persistor.persist()
-                            location.assign(
-                                getStoryUrl(multiplayer.instanceId) +
-                                    '&playerId=' +
-                                    multiplayer.otherPlayer.id
-                            )
-                        })
-                    })
+                    location.assign(
+                        getStoryUrl(multiplayer.instanceId) +
+                            '&playerId=' +
+                            multiplayer.otherPlayer.id
+                    )
                 }}>
                 {multiplayer.otherPlayer.name}
             </button>

--- a/core/multiplayer/components/multiplayer.tsx
+++ b/core/multiplayer/components/multiplayer.tsx
@@ -74,25 +74,14 @@ interface FromRouterProps {
 }
 const FromRouter = ({ instanceId, playerId }: FromRouterProps) => {
     const { setMultiplayer } = React.useContext(MultiplayerContext)
-    const { config, persistor } = React.useContext(StoryContext)
+    const { config } = React.useContext(StoryContext)
     const { identifier } = config
     const { multiplayer } = useMultiplayer(identifier, instanceId, playerId)
 
     React.useEffect(() => {
         if (multiplayer) {
-            // Try to avoid race conditions with purging local state before initializing it with the API response
-            persistor
-                .purge()
-                .then(() => {
-                    return persistor.flush()
-                })
-                .then(() => {
-                    persistor.pause()
-                })
-                .then(() => {
-                    setMultiplayer(multiplayer)
-                    emitPresence(identifier, instanceId, playerId)
-                })
+            setMultiplayer(multiplayer)
+            emitPresence(identifier, instanceId, playerId)
         }
     }, [multiplayer])
 

--- a/core/types.ts
+++ b/core/types.ts
@@ -38,8 +38,8 @@ export class Config {
     ) {
         this.identifier = identifier
         this.title = title
-        this.enableUndo = enableUndo
         this.players = players
+        this.enableUndo = players.length == 1 && enableUndo // Never enable undo for multiplayer
         this.language = language
         this.extra = extra
     }

--- a/stories/cloaks-of-darkness/chapters/cloakroom.tsx
+++ b/stories/cloaks-of-darkness/chapters/cloakroom.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { C, R, Section, Chapter, Nav } from 'core/components'
-import { PageType } from 'core/types'
+import { Next, PageType } from 'core/types'
 
 import useCloak, { CloakStatus } from '../use-cloak'
 
@@ -21,6 +21,7 @@ export const Page: PageType = () => {
                         last="one small brass hook"
                         tag="hook"
                         sync={false}
+                        next={Next.None}
                     />{' '}
                     remains.{' '}
                     <R

--- a/stories/cloaks-of-darkness/chapters/foyer.tsx
+++ b/stories/cloaks-of-darkness/chapters/foyer.tsx
@@ -2,7 +2,7 @@ import { C, R, Section, Chapter, Nav, When } from 'core/components'
 import Only from 'core/multiplayer/components/only'
 import Both from 'core/multiplayer/components/both'
 
-import { PageType } from 'core/types'
+import { Next, PageType } from 'core/types'
 import useLocation from 'core/multiplayer/hooks/use-location'
 import useInventory from 'core/hooks/use-inventory'
 
@@ -24,7 +24,12 @@ export const Page: PageType = () => {
                     </Only>
                     <Only playerName="raccoon">
                         The entrance from the street is{' '}
-                        <C options={[['back the way you came.']]} tag="back" sync={false} />
+                        <C
+                            options={[['back the way you came.']]}
+                            tag="back"
+                            sync={false}
+                            next={Next.None}
+                        />
                     </Only>
                     <R
                         tag="back"


### PR DESCRIPTION
Using redux-persist for storing local state between page refreshes just introduces the likelihood of state collisions, and makes it difficult to switch between players.

Other changes:

- Force enableUndo to be false in multiplayer
- Skip persist flushing if redux-persist is not activated in reset button
- Explicitly set next to `None` in non-section choices in Cloaks story
- Default section count to 0 rather than `NaN` when incrementing section bookmarks in replays.